### PR TITLE
Save users to Firestore

### DIFF
--- a/app/database.server.ts
+++ b/app/database.server.ts
@@ -95,11 +95,17 @@ export async function createProfileForUser(user: User) {
   }
 }
 
-type UpdateUserProfilePayload = Partial<UserProfile>;
-
+/**
+ * Updates a User in the database. The following fields are stripped from the
+ * payload:
+ * - createdAt
+ * - updatedAt (filled in automatically)
+ * - userId
+ * - githubUrl
+ */
 export async function updateProfileForUser(
   user: User,
-  updatedProfile: UpdateUserProfilePayload
+  updatedProfile: Partial<UserProfile>
 ) {
   const profileKey = getProfileKeyForUser(user);
 

--- a/app/database.server.ts
+++ b/app/database.server.ts
@@ -1,35 +1,116 @@
+import { Session } from "@remix-run/node";
 import { db } from "./firebase.server";
+import {
+  getClaimsFromSession,
+  getGitHubUserDataFromClaims,
+} from "./session.server";
 import { User, UserProfile } from "./types";
 
+// The names of collections in Firestore. Don't change these unless you're
+// absolutely sure of what you're doing!
 const USER_PROFILES_COLLECTION = "profiles";
+const USERS_COLLECTION = "users";
+
+const GITHUB_PROFILE_PREFIX = "github_";
 
 function getProfileKeyForUser(user: User) {
-  return `github_${user.githubLogin}`;
+  return GITHUB_PROFILE_PREFIX + user.githubLogin;
 }
 
 function getProfileKeyForSlug(slug: string) {
-  return `github_${slug}`;
+  return GITHUB_PROFILE_PREFIX + slug;
 }
 
+/**
+ * Create a new user in Firestore and return it. This makes a call to the GitHub
+ * API with the user's access token to access and store their `login`.
+ */
+export async function createUser(session: Session) {
+  // We need to make an API call to GitHub to get the user's login
+  const claims = await getClaimsFromSession(session);
+
+  if (!claims) {
+    throw new Error("Unable to decode claims before creating user");
+  }
+
+  const githubUserData = await getGitHubUserDataFromClaims(
+    session.get("accessToken"),
+    claims
+  );
+
+  const uid = claims.uid;
+
+  const user: User = {
+    uid,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    githubLogin: githubUserData.login,
+    displayName: claims.name,
+    pictureUrl: claims.picture || githubUserData.picture,
+    email: claims.email || githubUserData.email,
+  };
+
+  // The create() method fails if the user already exists
+  await db.collection(USERS_COLLECTION).doc(uid).create(user);
+
+  return user;
+}
+
+/**
+ * Fetch a user in our database by their unique `uid`
+ */
+export async function getUserByUid(uid: string) {
+  const user = await db.collection(USERS_COLLECTION).doc(uid).get();
+
+  try {
+    return user.data() as User;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Creates a profile for a specific user and then returns it. If there's already
+ * a profile, this will fail.
+ */
 export async function createProfileForUser(user: User) {
   const profile: UserProfile = {
     displayName: user.displayName,
-    userUid: user.uid,
+    userId: user.uid,
     githubUrl: `https://github.com/${user.githubLogin}`,
-    pictureUrl: user.avatar,
+    pictureUrl: user.pictureUrl,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
   };
 
-  await db
-    .collection(USER_PROFILES_COLLECTION)
-    .doc(getProfileKeyForUser(user))
-    .set(profile);
+  try {
+    await db
+      .collection(USER_PROFILES_COLLECTION)
+      .doc(getProfileKeyForUser(user))
+      .create(profile);
+
+    return profile;
+  } catch (_) {
+    return null;
+  }
 }
+
+type UpdateUserProfilePayload = Partial<UserProfile>;
 
 export async function updateProfileForUser(
   user: User,
-  updatedProfile: UserProfile
+  updatedProfile: UpdateUserProfilePayload
 ) {
   const profileKey = getProfileKeyForUser(user);
+
+  // Delete the fields we don't want to alter
+  delete updatedProfile.createdAt;
+  delete updatedProfile.updatedAt;
+  delete updatedProfile.userId;
+  delete updatedProfile.githubUrl;
+
+  // Send the correct time stamp
+  updatedProfile.updatedAt = new Date().toISOString();
 
   await db
     .collection(USER_PROFILES_COLLECTION)

--- a/app/routes/profile.tsx
+++ b/app/routes/profile.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "@remix-run/node";
 import type { LoaderFunction } from "@remix-run/node";
-import { getCurrentUser, getSession } from "~/session.server";
+import { destroySession, getCurrentUser, getSession } from "~/session.server";
 import { getProfileRouteForUser } from "~/utils/routes";
 
 // If the user is logged in, we attempt to redirect them to their profile
@@ -13,5 +13,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   }
 
   // Redirect to the login page
-  return redirect("/login");
+  return redirect("/login", {
+    headers: {
+      "Set-Cookie": await destroySession(session),
+    },
+  });
 };

--- a/app/routes/profile.tsx
+++ b/app/routes/profile.tsx
@@ -15,6 +15,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   // Redirect to the login page
   return redirect("/login", {
     headers: {
+      // It's possible that there is not current user but that the session still
+      // exists. So to avoid infinite redirects, we destroy the session before
+      // redirecting.
       "Set-Cookie": await destroySession(session),
     },
   });

--- a/app/routes/u.github/update-profile.ts
+++ b/app/routes/u.github/update-profile.ts
@@ -1,7 +1,6 @@
 import { ActionFunction, redirect } from "@remix-run/node";
 import { updateProfileForUser } from "~/database.server";
 import { getCurrentUser, getSession } from "~/session.server";
-import { UserProfile } from "~/types";
 import { getProfileRouteForUser } from "~/utils/routes";
 
 export const action: ActionFunction = async ({ request }) => {
@@ -14,8 +13,8 @@ export const action: ActionFunction = async ({ request }) => {
 
   const formData = await request.formData();
 
-  const twitterUrl = formData.get("twitter")?.toString() ?? "";
-  const linkedinUrl = formData.get("linkedin")?.toString() ?? "";
+  const twitterUrl = formData.get("twitter")?.toString();
+  const linkedinUrl = formData.get("linkedin")?.toString();
 
   // TODO
   // const techInterests = formData.get("techInterests");
@@ -23,15 +22,13 @@ export const action: ActionFunction = async ({ request }) => {
   // const contributionInterests = formData.get("contributionInterests");
   // const joinDiscord = formData.get("joinDiscord");
 
-  const userProfile: UserProfile = {
+  await updateProfileForUser(currentUser, {
     displayName: currentUser.displayName,
-    userUid: currentUser.uid,
-    pictureUrl: currentUser.avatar,
+    userId: currentUser.uid,
+    pictureUrl: currentUser.pictureUrl,
     linkedinUrl,
     twitterUrl,
-  };
-
-  await updateProfileForUser(currentUser, userProfile);
+  });
 
   return redirect(getProfileRouteForUser(currentUser));
 };

--- a/app/types.ts
+++ b/app/types.ts
@@ -105,13 +105,18 @@ export type User = {
   uid: string;
   githubLogin: string;
   displayName: string;
-  avatar?: string;
   email?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  discordUserId?: string | null;
+  pictureUrl?: string;
 };
 
 export type UserProfile = {
-  userUid: string;
+  userId: string;
   displayName: string;
+  createdAt: string;
+  updatedAt: string;
   twitterUrl?: string;
   linkedinUrl?: string;
   githubUrl?: string;


### PR DESCRIPTION
We need to save users to Firestore in order to avoid making an API call to GitHub every time someone loads a protected page. With this approach, we only make a single call to determine the user's `login` when they sign up, and then all the lookups happen in Firestore.

**New user flow:**

1. user logs in with GitHub
2. we check whether they exist in our database (they don't!)
3. we create a new User for them
4. we check whether they have a project in our database (they don't!)
5. we create a new UserProject for them
6. we redirect the user to the Welcome page

**Existing user flow:**

1. user logs in with GitHub
2. we check that they exist in our database (they do!)
3. we check that they have a project in our database (they do!)
4. we redirect them to their project


Here's a video where I sign up locally (using the Firebase emulator):

https://user-images.githubusercontent.com/3411183/169122171-2be39ae0-f3fc-4de1-b068-bd17401f36e7.mov



This required some changes to the `User` and `UserProfile` models to make data easier to access in Firestore. This includes the new fields `createdAt` and `updatedAt` that will help audit changes, and might even show up in the UI.

```ts
export type User = {
  uid: string;
  githubLogin: string;
  displayName: string;
  createdAt: string;
  updatedAt: string;
};

export type UserProfile = {
  userId: string;
  displayName: string;
  createdAt: string;
  updatedAt: string;
};
```