### PR TITLE
Make sessions last 2 weeks instead of 1 hour

### DIFF
--- a/app/components/HeaderDropdown.tsx
+++ b/app/components/HeaderDropdown.tsx
@@ -57,17 +57,11 @@ const HeaderDropdown: FC<Props> = ({ userInfo }) => {
               alt="Your avatar"
             />
           )}
-          <div className="overflow-hidden">
-            <p
-              className="text-sm text-light-type font-semibold truncate"
-              title={userInfo.displayName}
-            >
+          <div>
+            <p className="text-sm text-light-type font-semibold">
               {userInfo.displayName}
             </p>
-            <p
-              className="text-xs text-light-type-medium truncate"
-              title={userInfo.githubLogin}
-            >
+            <p className="text-xs text-light-type-medium">
               {userInfo.githubLogin}
             </p>
           </div>

--- a/app/components/HeaderDropdown.tsx
+++ b/app/components/HeaderDropdown.tsx
@@ -57,11 +57,17 @@ const HeaderDropdown: FC<Props> = ({ userInfo }) => {
               alt="Your avatar"
             />
           )}
-          <div>
-            <p className="text-sm text-light-type font-semibold">
+          <div className="overflow-hidden">
+            <p
+              className="text-sm text-light-type font-semibold truncate"
+              title={userInfo.displayName}
+            >
               {userInfo.displayName}
             </p>
-            <p className="text-xs text-light-type-medium">
+            <p
+              className="text-xs text-light-type-medium truncate"
+              title={userInfo.githubLogin}
+            >
               {userInfo.githubLogin}
             </p>
           </div>

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -1,21 +1,11 @@
-import { json, LoaderFunction, redirect } from "@remix-run/node";
+import { json, LoaderFunction } from "@remix-run/node";
 import type { ActionFunction } from "@remix-run/node";
 import { useSubmit } from "@remix-run/react";
 import { FC, useEffect } from "react";
-import {
-  destroySession,
-  getCurrentUserOrRedirect,
-  getSession,
-} from "~/session.server";
+import { destroyUserSession, getCurrentUserOrRedirect } from "~/session.server";
 
 export const action: ActionFunction = async ({ request }) => {
-  let session = await getSession(request.headers.get("Cookie"));
-  session.unset("idToken");
-  session.unset("accessToken");
-
-  return redirect("/", {
-    headers: { "Set-Cookie": await destroySession(session) },
-  });
+  return await destroyUserSession(request);
 };
 
 export const loader: LoaderFunction = async ({ request }) => {

--- a/app/routes/u.github/$slug.tsx
+++ b/app/routes/u.github/$slug.tsx
@@ -9,14 +9,13 @@ import LinkedInIcon from "~/components/icons/LinkedInIcon";
 import TwitterIcon from "~/components/icons/TwitterIcon";
 import Interests from "~/components/profile/Interests";
 import { getUserProfileBySlug } from "~/database.server";
-import { getCurrentUser, getSession } from "~/session.server";
+import { getCurrentUser } from "~/session.server";
 import { UserProfile } from "~/types";
 
 export const loader: LoaderFunction = async ({ params, request }) => {
   const slug = params.slug as string; // This can't be undefined or we wouldn't be here
 
-  const session = await getSession(request.headers.get("Cookie"));
-  const user = await getCurrentUser(session);
+  const user = await getCurrentUser(request);
   const profile = await getUserProfileBySlug(slug);
 
   if (!profile) {

--- a/app/routes/u.github/update-profile.ts
+++ b/app/routes/u.github/update-profile.ts
@@ -1,6 +1,6 @@
 import { ActionFunction, redirect } from "@remix-run/node";
 import { updateProfileForUser } from "~/database.server";
-import { getCurrentUser, getSession } from "~/session.server";
+import { getCurrentUser } from "~/session.server";
 import { UserProfile } from "~/types";
 import { getProfileRouteForUser } from "~/utils/routes";
 
@@ -10,8 +10,7 @@ function arrayFromString(value?: string): string[] {
 }
 
 export const action: ActionFunction = async ({ request }) => {
-  const session = await getSession(request.headers.get("Cookie"));
-  const currentUser = await getCurrentUser(session);
+  const currentUser = await getCurrentUser(request);
 
   if (!currentUser) {
     throw new Error("You must be logged in to save your profile");

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -115,20 +115,6 @@ export async function getCurrentSession(request: Request) {
   }
 }
 
-export async function getVerifiedUserToken(request: Request) {
-  const cookieSession = await storage.getSession(request.headers.get("Cookie"));
-  const token = cookieSession.get("token");
-  if (!token) return null;
-
-  try {
-    const tokenUser = await auth.verifySessionCookie(token, true);
-    return tokenUser;
-  } catch (error) {
-    console.log(error);
-    return null;
-  }
-}
-
 export async function destroyUserSession(request: Request, redirectTo = "/") {
   const session = await storage.getSession(request.headers.get("Cookie"));
   const newCookie = await storage.destroySession(session);
@@ -170,30 +156,13 @@ export async function getGitHubUserDataFromClaims(
   }
 }
 
-export async function getClaimsFromSession(request: Request) {
-  const cookieSession = await storage.getSession(request.headers.get("Cookie"));
-  const token = cookieSession.get("token");
-
-  let decodedClaims: DecodedIdToken | undefined;
-
-  try {
-    // https://firebase.google.com/docs/auth/admin/verify-id-tokens
-    decodedClaims = await auth.verifySessionCookie(token);
-  } catch (err) {
-    // The session isn't valid anymore so return undefined
-    return null;
-  }
-
-  return decodedClaims;
-}
-
 /**
  * Returns the user that's currently logged in, or null if there is none.
  *
  * @see https://firebase.google.com/docs/auth/admin/verify-id-tokens#web
  */
 export async function getCurrentUser(request: Request): Promise<User | null> {
-  const claims = await getClaimsFromSession(request);
+  const claims = await getCurrentSession(request);
 
   if (!claims) {
     return null;

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -1,7 +1,12 @@
 import { Octokit } from "@octokit/rest";
 import { createCookieSessionStorage, redirect, Session } from "@remix-run/node";
 import { DecodedIdToken } from "firebase-admin/auth";
-import { getUserByUid } from "./database.server";
+import {
+  createProfileForUser,
+  createUser,
+  getUserByUid,
+  getUserProfileBySlug,
+} from "./database.server";
 import { auth } from "./firebase.server";
 import { User, UserInfo } from "./types";
 
@@ -18,7 +23,7 @@ if (!sessionCookieSecret) {
   );
 }
 
-const { getSession, commitSession, destroySession } =
+const storage =
   // Remix's built-in session handling
   // https://remix.run/docs/en/v1/api/remix#sessions
   createCookieSessionStorage({
@@ -35,7 +40,101 @@ const { getSession, commitSession, destroySession } =
     },
   });
 
-export { getSession, commitSession, destroySession };
+const fiveMinutesInSeconds = 60 * 5;
+const fiveMinutesInMilliseconds = fiveMinutesInSeconds * 1000;
+
+const twoWeeksInSeconds = 60 * 60 * 24 * 14;
+const twoWeeksInMilliseconds = twoWeeksInSeconds * 1000;
+
+// Session last 2 weeks by default. For testing purposes, we can add a
+// DEBUG_SESSION environment variable to make the sessions last 5 minutes, which
+// is the minimum allowed time for a session
+const COOKIE_EXPIRATION = {
+  seconds: process.env.DEBUG_SESSION ? fiveMinutesInSeconds : twoWeeksInSeconds,
+  milliseconds: process.env.DEBUG_SESSION
+    ? fiveMinutesInMilliseconds
+    : twoWeeksInMilliseconds,
+};
+
+/**
+ * Use this to register a new user or log in an existing user. This creates a
+ * session cookie, which can then be used to authenticate further requests.
+ *
+ * This method has 2 potential side effects:
+ * - if the user doesn't exist, it creates a new User document in Firestore
+ * - if the user doesn't have a profile, it creates a new UserProfile document
+ *   in Firestore
+ */
+export async function createUserSession(idToken: string, accessToken: string) {
+  const token = await auth.createSessionCookie(idToken, {
+    expiresIn: COOKIE_EXPIRATION.milliseconds,
+  });
+  const session = await storage.getSession();
+  session.set("token", token);
+
+  // Check that we have a matching user for this token. If not, create one.
+  const decodedToken = await auth.verifySessionCookie(token, true);
+  let user = await getUserByUid(decodedToken.uid);
+
+  if (user == null) {
+    user = await createUser(decodedToken, accessToken);
+  }
+
+  // Check whether the user has a profile page. If not, ask them to create one.
+  let redirectPath: string;
+  const profile = await getUserProfileBySlug(user.githubLogin);
+
+  if (profile) {
+    // If the user already has a profile, we redirect to it
+    redirectPath = `/u/github/${user.githubLogin}`;
+  } else {
+    // If the user doesn't have a profile yet, we create one and send them to
+    // the Welcome page to enter some information
+    await createProfileForUser(user);
+
+    redirectPath = `/u/github/${user.githubLogin}/welcome`;
+  }
+
+  return redirect(redirectPath, {
+    headers: {
+      "Set-Cookie": await storage.commitSession(session),
+    },
+  });
+}
+
+export async function getCurrentSession(request: Request) {
+  const cookieSession = await storage.getSession(request.headers.get("Cookie"));
+  const token = cookieSession.get("token");
+  if (!token) return null;
+
+  try {
+    const tokenUser = await auth.verifySessionCookie(token, true);
+    return tokenUser;
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function getVerifiedUserToken(request: Request) {
+  const cookieSession = await storage.getSession(request.headers.get("Cookie"));
+  const token = cookieSession.get("token");
+  if (!token) return null;
+
+  try {
+    const tokenUser = await auth.verifySessionCookie(token, true);
+    return tokenUser;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+}
+
+export async function destroyUserSession(request: Request, redirectTo = "/") {
+  const session = await storage.getSession(request.headers.get("Cookie"));
+  const newCookie = await storage.destroySession(session);
+
+  return redirect(redirectTo, { headers: { "Set-Cookie": newCookie } });
+}
 
 /**
  * Returns information from GitHub about the user associated with the access
@@ -71,22 +170,15 @@ export async function getGitHubUserDataFromClaims(
   }
 }
 
-export async function getClaimsFromSession(session: Session) {
-  const idToken = session.get("idToken");
-
-  const error = session.get("error");
-  if (error) {
-    throw new Error(error);
-  }
-
-  if (typeof idToken !== "string") {
-    return null;
-  }
+export async function getClaimsFromSession(request: Request) {
+  const cookieSession = await storage.getSession(request.headers.get("Cookie"));
+  const token = cookieSession.get("token");
 
   let decodedClaims: DecodedIdToken | undefined;
 
   try {
-    decodedClaims = await auth.verifyIdToken(idToken);
+    // https://firebase.google.com/docs/auth/admin/verify-id-tokens
+    decodedClaims = await auth.verifySessionCookie(token);
   } catch (err) {
     // The session isn't valid anymore so return undefined
     return null;
@@ -100,8 +192,8 @@ export async function getClaimsFromSession(session: Session) {
  *
  * @see https://firebase.google.com/docs/auth/admin/verify-id-tokens#web
  */
-export async function getCurrentUser(session: Session): Promise<User | null> {
-  const claims = await getClaimsFromSession(session);
+export async function getCurrentUser(request: Request): Promise<User | null> {
+  const claims = await getClaimsFromSession(request);
 
   if (!claims) {
     return null;
@@ -118,8 +210,8 @@ export async function getCurrentUserOrRedirect(
   request: Request,
   redirectTo = "/login"
 ) {
-  const session = await getSession(request.headers.get("Cookie"));
-  const user = await getCurrentUser(session);
+  const session = await storage.getSession(request.headers.get("Cookie"));
+  const user = await getCurrentUser(request);
 
   if (!user) {
     session.unset("idToken");
@@ -129,7 +221,7 @@ export async function getCurrentUserOrRedirect(
         // It's possible that there is no current user but that the session still
         // exists. So to avoid infinite redirects, we destroy the session before
         // redirecting.
-        "Set-Cookie": await destroySession(session),
+        "Set-Cookie": await storage.destroySession(session),
       },
     });
   }
@@ -138,13 +230,12 @@ export async function getCurrentUserOrRedirect(
 }
 
 export async function isLoggedIn(request: Request) {
-  const session = await getSession(request.headers.get("Cookie"));
+  const session = await storage.getSession(request.headers.get("Cookie"));
   return session.has("idToken");
 }
 
 export async function getCurrentUserInfo(request: Request) {
-  const session = await getSession(request.headers.get("Cookie"));
-  const user = await getCurrentUser(session);
+  const user = await getCurrentUser(request);
   if (!user) {
     return null;
   }


### PR DESCRIPTION
The goal of this PR was to extend the session duration from 1 hour to 2 weeks.

While debugging, I found out that I hadn't set up the system properly: I was storing the user's `idToken` on a session that lasted 2 weeks and using the `firebase-admin` SDK to verify that token. However, `idToken`s expire after 1 hour! This meant that after 1 hour, the verification would fail and the session would be destroyed even though it was supposed to last 2 weeks.

The correct approach is to exchange the `idToken` provided by Firebase's client-side authentication SDK and create a session cookie from it using their Node SDK. They provide a method called `createSessionCookie()`, which takes an `idToken` and generates a `token` that can be stored on the session. I learned all this [from their documentation](https://firebase.google.com/docs/auth/admin/manage-cookies).

The last piece of the puzzle was to verify the session using that `token` on subsequent page loads. This required replacing the `verifyIdToken` method with `verifySessionToken` (both are `firebase-admin` methods.)