### PR TITLE
Add review map images to portfolio items

### DIFF
--- a/app/components/PortfolioItemCard.tsx
+++ b/app/components/PortfolioItemCard.tsx
@@ -36,7 +36,7 @@ const PortfolioItemCard: FC<Props> = (props) => {
             <img
               src={props.portfolioItem.reviewMapImageUrl}
               alt=""
-              className="hidden md:block object-cover flex-shrink-0 border-r border-light-border rounded-tl-lg"
+              className="hidden sm:block object-cover flex-shrink-0 border-r border-light-border rounded-tl-lg"
               style={{ height: 200, aspectRatio: "4 / 3" }}
             />
           )}

--- a/app/components/PortfolioItemCard.tsx
+++ b/app/components/PortfolioItemCard.tsx
@@ -37,7 +37,7 @@ const PortfolioItemCard: FC<Props> = (props) => {
               src={props.portfolioItem.reviewMapImageUrl}
               alt=""
               className="hidden md:block object-cover flex-shrink-0 border-r border-light-border rounded-tl-lg"
-              style={{ height: 200, aspectRatio: "16 / 9" }}
+              style={{ height: 200, aspectRatio: "4 / 3" }}
             />
           )}
           <div>

--- a/app/routes/api/check-review-map-image.ts
+++ b/app/routes/api/check-review-map-image.ts
@@ -1,0 +1,38 @@
+import { ActionFunction, json } from "@remix-run/node";
+import axios from "axios";
+import { getReviewMapImageUrlFromPullRequest } from "~/utils/codesee";
+
+/**
+ * Checks whether a pull request has a Review Map image
+ */
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const url = formData.get("url")?.toString();
+
+  if (typeof url !== "string") {
+    return new Response(null, {
+      status: 400,
+      statusText: "Malformed request",
+    });
+  }
+
+  const imageUrl = getReviewMapImageUrlFromPullRequest(url);
+
+  if (imageUrl == null) {
+    return new Response(null, {
+      status: 400,
+      statusText: "Malformed request",
+    });
+  }
+
+  return await axios({
+    url: imageUrl,
+    method: "GET",
+  })
+    .then(() => {
+      return json({ imageUrl });
+    })
+    .catch(() => {
+      return json({}, { status: 404, statusText: "Not found" });
+    });
+};

--- a/app/routes/u.github/$slug/contribution.tsx
+++ b/app/routes/u.github/$slug/contribution.tsx
@@ -1,4 +1,9 @@
-import { Form, useActionData, useLoaderData } from "@remix-run/react";
+import {
+  Form,
+  useActionData,
+  useFetcher,
+  useLoaderData,
+} from "@remix-run/react";
 import { FC, useRef, useState } from "react";
 import {
   ActionFunction,
@@ -11,7 +16,6 @@ import TextField from "~/components/TextField";
 import { createPortfolioItem } from "~/database.server";
 import { getCurrentUser } from "~/session.server";
 import { CreatePortfolioItemPayload } from "~/types";
-import { isValidReviewMapUrl } from "~/utils/codesee";
 import { isValidPullRequestUrl } from "~/utils/repo-url";
 import { getProfileRouteForUser } from "~/utils/routes";
 import TextArea from "~/components/TextArea";
@@ -88,10 +92,7 @@ export const action: ActionFunction = async ({ request }) => {
     title: title as string,
   };
 
-  if (
-    typeof reviewMapImageUrl === "string" &&
-    isValidReviewMapUrl(reviewMapImageUrl)
-  ) {
+  if (typeof reviewMapImageUrl === "string") {
     newPortfolioItem.reviewMapImageUrl = reviewMapImageUrl;
   }
 
@@ -108,11 +109,22 @@ const Contribution: FC = () => {
 
   const descriptionRef = useRef<HTMLInputElement>(null);
 
+  const fetcher = useFetcher();
   const onUpdatePullRequestUrl = (url: string) => {
-    setPullRequestUrl(url);
+    if (pullRequestUrl !== url) {
+      setPullRequestUrl(url);
 
-    // Focus on the next input field
-    descriptionRef.current?.focus();
+      // Focus on the next input field
+      descriptionRef.current?.focus();
+
+      const data = new FormData();
+      data.set("url", url);
+      console.log("submitting");
+      fetcher.submit(data, {
+        action: "/api/check-review-map-image",
+        method: "post",
+      });
+    }
   };
 
   return (
@@ -134,6 +146,11 @@ const Contribution: FC = () => {
             action={`/u/github/${slug}/contribution`}
             className="space-y-4"
           >
+            <input
+              type="hidden"
+              name="reviewMapImageUrl"
+              value={fetcher?.data?.imageUrl}
+            />
             <input
               type="hidden"
               value={pullRequestUrl || ""}

--- a/app/routes/u.github/$slug/contribution.tsx
+++ b/app/routes/u.github/$slug/contribution.tsx
@@ -117,9 +117,9 @@ const Contribution: FC = () => {
       // Focus on the next input field
       descriptionRef.current?.focus();
 
+      // In the background, check whether the PR URL has a Review Map
       const data = new FormData();
       data.set("url", url);
-      console.log("submitting");
       fetcher.submit(data, {
         action: "/api/check-review-map-image",
         method: "post",

--- a/app/utils/codesee.ts
+++ b/app/utils/codesee.ts
@@ -1,8 +1,31 @@
+import { isValidPullRequestUrl } from "./repo-url";
+
 const CODESEE_REVIEW_MAP_PREFIXES = [
   "https://app.codesee.io/maps/review/github",
   "https://app.codesee.io/r/reviews?pr=",
 ];
 
+const CODESEE_REVIEW_MAPS_BUCKET =
+  "https://s3.us-east-2.amazonaws.com/maps.codesee.io/images/github/";
+
 export function isValidReviewMapUrl(url: string) {
   return CODESEE_REVIEW_MAP_PREFIXES.some((prefix) => url.startsWith(prefix));
+}
+
+/**
+ *
+ * @example getReviewMapImageUrlFromPullRequest("https://github.com/distributeaid/shipment-tracker/pull/819")
+ * // https://s3.us-east-2.amazonaws.com/maps.codesee.io/images/github/distributeaid/shipment-tracker/819/latest.svg
+ */
+export function getReviewMapImageUrlFromPullRequest(url: string) {
+  const prDetails = isValidPullRequestUrl(url);
+  if (prDetails) {
+    const { owner, name, pullRequestNumber } = prDetails;
+    return (
+      CODESEE_REVIEW_MAPS_BUCKET +
+      `${owner}/${name}/${pullRequestNumber}/latest.svg`
+    );
+  }
+
+  return null;
 }


### PR DESCRIPTION
When people upload a new portfolio item, we now add a preview of that pull request's Review Map. If we can't find a preview, we don't add anything. This operation happens on the frontend while the user is filling out the rest of the form so that it appears seamless!

<img width="929" alt="Screen Shot 2022-06-08 at 9 22 41 AM" src="https://user-images.githubusercontent.com/3411183/172667999-3f11c5a2-ea4d-4508-81d1-7d62bb359598.png">
