### PR TITLE
Prevent listing duplicate projects

### DIFF
--- a/app/routes/list-project.tsx
+++ b/app/routes/list-project.tsx
@@ -39,6 +39,7 @@ import {
 } from "~/utils/project-submission";
 import { createNewPullRequest } from "~/github.server";
 import { getRepoOwnerAndName } from "~/utils/repo-url";
+import { getProjectByRepoUrl } from "~/projects.server";
 
 export function links() {
   return [
@@ -83,6 +84,16 @@ export const action: ActionFunction = async ({ request }) => {
 
   if (!repoUrl) {
     throw new Error("Missing repo URL in new project form");
+  }
+
+  // Verify that we don't already have a project for this repository
+  const matchingProject = getProjectByRepoUrl(repoUrl);
+  if (matchingProject) {
+    return json({
+      validationErrors: {
+        repoUrl: "This project is already listed on Open Source Hub",
+      },
+    });
   }
 
   // Create a new pull request with the content of the form


### PR DESCRIPTION
### What changed

When someone attempts to list their project, we're now checking whether that project is already listed on the site. If so, we prevent them from submitting and show a validation error:

<img width="476" alt="Screen Shot 2022-09-30 at 10 20 32 AM" src="https://user-images.githubusercontent.com/3411183/193323757-ccaa932a-1746-4a29-8c7a-e0267e5f0af6.png">
