### PR TITLE
Add a confirmation before submitting a project

### DIFF
--- a/app/components/ModalWrapper.tsx
+++ b/app/components/ModalWrapper.tsx
@@ -1,0 +1,29 @@
+import { FC, useEffect } from "react";
+
+type Props = {
+  isOpen: boolean;
+};
+
+const ModalWrapper: FC<Props> = ({ children, isOpen }) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add("overflow-hidden");
+    }
+
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+    };
+  }, [isOpen]);
+
+  if (isOpen) {
+    return (
+      <div className="fixed inset-0 bg-black-900/75 z-50 p-4 overflow-auto">
+        {children}
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default ModalWrapper;

--- a/app/components/ProjectPreview.tsx
+++ b/app/components/ProjectPreview.tsx
@@ -1,8 +1,8 @@
 import { FC } from "react";
-import cx from "classnames";
 import { Project } from "~/types";
 import ProjectTemplate from "./ProjectTemplate";
 import Button from "./Button";
+import ModalWrapper from "./ModalWrapper";
 
 type Props = {
   isOpen: boolean;
@@ -18,11 +18,7 @@ type Props = {
  */
 const ProjectPreview: FC<Props> = ({ isOpen, project, closePreview }) => {
   return (
-    <div
-      className={cx("fixed inset-0 p-2 md:p-6 z-50 bg-black-700/75", {
-        hidden: !isOpen,
-      })}
-    >
+    <ModalWrapper isOpen={isOpen}>
       <div className="max-w-6xl mx-auto shadow-lg bg-black-30 rounded-lg border-t-4 border-light-interactive">
         <div className="bg-light-interactive px-4 pb-4 pt-3 flex justify-between items-center">
           <h2 className="font-semibold text-xl text-white text-center">
@@ -34,7 +30,7 @@ const ProjectPreview: FC<Props> = ({ isOpen, project, closePreview }) => {
           {project && <ProjectTemplate project={project} />}
         </div>
       </div>
-    </div>
+    </ModalWrapper>
   );
 };
 

--- a/app/components/ProjectSubmissionConfirmation.tsx
+++ b/app/components/ProjectSubmissionConfirmation.tsx
@@ -1,0 +1,41 @@
+import { FC } from "react";
+import Button from "./Button";
+import ModalWrapper from "./ModalWrapper";
+
+type Props = {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+const ProjectSubmissionConfirmation: FC<Props> = ({
+  isOpen,
+  onCancel,
+  onConfirm,
+}) => {
+  return (
+    <ModalWrapper isOpen={isOpen}>
+      <div className="h-full flex items-center justify-center p-4">
+        <div className="bg-white rounded-lg p-6 shadow-lg max-w-sm">
+          <h2 className="text-lg font-semibold text-light-type mb-2 flex items-center">
+            Ready to submit your project?
+          </h2>
+          <p className="text-light-type text-sm">
+            This will open a pull request in the Open Source Hub repository,
+            where someone from the team will review your changes.
+          </p>
+          <div className="mt-6 flex gap-4 justify-between">
+            <Button type="button" variant="secondary" onClick={onCancel}>
+              Not yet
+            </Button>
+            <Button type="button" variant="brand" onClick={onConfirm}>
+              Yes, submit!
+            </Button>
+          </div>
+        </div>
+      </div>
+    </ModalWrapper>
+  );
+};
+
+export default ProjectSubmissionConfirmation;

--- a/app/components/ProjectSubmissionSpinner.tsx
+++ b/app/components/ProjectSubmissionSpinner.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+import ModalWrapper from "./ModalWrapper";
 import Spinner from "./Spinner";
 
 type Props = {
@@ -11,9 +12,9 @@ type Props = {
  * @see list-projects.tsx
  */
 const ProjectSubmissionSpinner: FC<Props> = ({ state }) => {
-  if (state === "submitting") {
-    return (
-      <div className="fixed inset-0 bg-black-900/75 z-50 flex items-center justify-center p-4">
+  return (
+    <ModalWrapper isOpen={state === "submitting"}>
+      <div className="h-full flex items-center justify-center p-4">
         <div className="bg-white rounded-lg p-6 shadow-lg">
           <h2 className="text-lg font-semibold text-light-type mb-2 flex items-center">
             <Spinner className="mr-2 h-5 w-5" /> Submitting your project...
@@ -25,10 +26,8 @@ const ProjectSubmissionSpinner: FC<Props> = ({ state }) => {
           </ul>
         </div>
       </div>
-    );
-  }
-
-  return null;
+    </ModalWrapper>
+  );
 };
 
 export default ProjectSubmissionSpinner;

--- a/app/routes/list-project.tsx
+++ b/app/routes/list-project.tsx
@@ -1,4 +1,9 @@
-import { Form, useActionData, useTransition } from "@remix-run/react";
+import {
+  Form,
+  useActionData,
+  useSubmit,
+  useTransition,
+} from "@remix-run/react";
 import { ChangeEvent, FC, useRef, useState } from "react";
 import ReactSelect, { MultiValue } from "react-select";
 import cx from "classnames";
@@ -40,6 +45,7 @@ import {
 import { createNewPullRequest } from "~/github.server";
 import { getRepoOwnerAndName } from "~/utils/repo-url";
 import { getProjectByRepoUrl } from "~/projects.server";
+import ProjectSubmissionConfirmation from "~/components/ProjectSubmissionConfirmation";
 
 export function links() {
   return [
@@ -120,6 +126,7 @@ type TagsState = {
 const ListProject: FC = () => {
   const transition = useTransition();
   const actionData = useActionData();
+  const submit = useSubmit();
 
   // The 3 tag dropdowns are controlled components and we keep track of their state here
   const [tags, setTags] = useState<TagsState>({
@@ -217,12 +224,24 @@ const ListProject: FC = () => {
     }
   };
 
+  // Show a confirmation modal before submitting the form
+  const [confirmation, setConfirmation] = useState(false);
+  const submitForm = () => {
+    setConfirmation(false);
+    submit(formRef.current);
+  };
+
   return (
     <div>
       <ProjectPreview
         isOpen={showPreview}
         project={projectPreview}
         closePreview={() => setShowPreview(false)}
+      />
+      <ProjectSubmissionConfirmation
+        isOpen={confirmation}
+        onCancel={() => setConfirmation(false)}
+        onConfirm={submitForm}
       />
       <ProjectSubmissionSpinner state={transition.state} />
       <main className="max-w-4xl mx-auto pt-12 px-2 pb-24">
@@ -346,12 +365,11 @@ const ListProject: FC = () => {
               </div>
             </div>
           </div>
-
           <div className="md:flex gap-6 bg-white border border-light-border p-4 rounded-lg mb-8">
             <div className="mb-6 md:mb-0 flex-auto md:w-2/3">
               <h2 className="font-bold text-lg mb-4">Project tags</h2>
               <div className="space-y-4">
-                <div className="h-20">
+                <div>
                   <label className="input-label">
                     Tech focus <RequiredMarker />
                   </label>
@@ -370,7 +388,7 @@ const ListProject: FC = () => {
                   />
                   <FieldError error={actionData?.validationErrors?.languages} />
                 </div>
-                <div className="h-20">
+                <div>
                   <label className="input-label">
                     Contributor roles <RequiredMarker />
                   </label>
@@ -391,7 +409,7 @@ const ListProject: FC = () => {
                     error={actionData?.validationErrors?.currentlySeeking}
                   />
                 </div>
-                <div className="h-20">
+                <div>
                   <label className="input-label">
                     Subjects <RequiredMarker />
                   </label>
@@ -415,21 +433,21 @@ const ListProject: FC = () => {
             <div className="flex-auto md:w-1/3">
               <h2 className="font-bold text-lg mb-4">Contribution overview</h2>
               <div className="space-y-4">
-                <div className="h-20">
+                <div>
                   <TextField
                     id="automatedDevEnvironment"
                     label="Automated dev environment"
                     placeholder="gitpod.io"
                   />
                 </div>
-                <div className="h-20">
+                <div>
                   <TextField
                     id="mainLocation"
                     label="Maintainer location"
                     placeholder="Africa"
                   />
                 </div>
-                <div className="h-20">
+                <div>
                   <TextField
                     id="idealEffort"
                     label="Ideal contributor effort"
@@ -449,7 +467,6 @@ const ListProject: FC = () => {
               </div>
             </div>
           </div>
-
           <div className="bg-white border border-light-border p-4 rounded-lg mb-6">
             <h2 className="font-bold text-lg mb-4">Content</h2>
             <div className="mb-4">
@@ -473,7 +490,6 @@ const ListProject: FC = () => {
               <FieldError error={actionData?.validationErrors?.contributing} />
             </div>
           </div>
-
           <div className="bg-white border border-light-border p-4 rounded-lg mb-20">
             <h2 className="font-bold text-lg mb-4">CodeSee Map</h2>
             <p>
@@ -525,7 +541,13 @@ const ListProject: FC = () => {
           </div>
 
           <div className="sticky bottom-4 bg-white border border-light-border p-4 rounded-lg flex gap-4 items-center shadow-lg">
-            <Button variant="brand">Submit</Button>
+            <Button
+              type="button"
+              onClick={() => setConfirmation(true)}
+              variant="brand"
+            >
+              Submit
+            </Button>
             <Button type="button" onClick={displayPreview}>
               Preview
             </Button>


### PR DESCRIPTION
### What changed

I added a confirmation modal before submitting a project.

I also added a `ModalWrapper` component because the page uses 3 of those 😅 

<img width="477" alt="Screen Shot 2022-09-30 at 11 37 09 AM" src="https://user-images.githubusercontent.com/3411183/193335191-4cc8b79d-29ec-4efb-955e-211b501a341b.png">
