### PR TITLE
Add the ability to list Review Maps in projects

### DIFF
--- a/app/components/ProjectTemplate.tsx
+++ b/app/components/ProjectTemplate.tsx
@@ -13,6 +13,7 @@ import HelpWanted from "~/components/markdown/HelpWanted";
 import HacktoberfestIssues from "~/components/markdown/HacktoberfestIssues";
 import FeaturedCodeSeeMap from "~/components/markdown/FeaturedCodeSeeMap";
 import Maps from "~/components/Maps";
+import ReviewMaps from "./ReviewMaps";
 
 type Props = {
   project: Project;
@@ -139,6 +140,7 @@ const ProjectTemplate: FC<Props> = ({
               githubData={githubData}
               repoUrl={project.attributes.repoUrl}
             />
+            <ReviewMaps reviewMaps={project.attributes.reviewMapUrls} />
             <Maps maps={project.attributes.maps} />
           </div>
         </div>

--- a/app/components/RepeatableTextFields.tsx
+++ b/app/components/RepeatableTextFields.tsx
@@ -7,6 +7,7 @@ type Props = {
   maxFields?: number;
   label: ReactNode;
   name: string;
+  type?: string;
 };
 
 /**
@@ -21,6 +22,7 @@ const RepeatableTextFields: FC<Props> = ({
   label,
   name,
   maxFields = 10,
+  type = "text",
 }) => {
   // Give each field a unique id so that we can delete them properly
   const [fields, setFields] = useState([nanoid()]);
@@ -43,7 +45,7 @@ const RepeatableTextFields: FC<Props> = ({
         <div key={fieldId} className="flex gap-4">
           <input
             className="input"
-            type="text"
+            type={type}
             placeholder={placeholder}
             name={`${name}_${index}`}
           />

--- a/app/components/RepeatableTextFields.tsx
+++ b/app/components/RepeatableTextFields.tsx
@@ -1,0 +1,72 @@
+import { FC, ReactNode, useState } from "react";
+import { nanoid } from "nanoid";
+import Button from "./Button";
+
+type Props = {
+  placeholder?: string;
+  maxFields?: number;
+  label: ReactNode;
+  name: string;
+};
+
+/**
+ * Renders a group of one or more input fields with buttons to add and remove
+ * each field. Use the getRepeatableFieldValues() function to extract values in
+ * a form.
+ *
+ * @see getRepeatableFieldValues
+ */
+const RepeatableTextFields: FC<Props> = ({
+  placeholder,
+  label,
+  name,
+  maxFields = 10,
+}) => {
+  // Give each field a unique id so that we can delete them properly
+  const [fields, setFields] = useState([nanoid()]);
+
+  const canAdd = fields.length < maxFields;
+  const canRemove = fields.length > 1;
+
+  const addField = () => {
+    setFields((prev) => [...prev, nanoid()]);
+  };
+
+  const removeField = (id: string) => {
+    setFields((prev) => prev.filter((f) => f !== id));
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="input-label">{label}</label>
+      {fields.map((fieldId, index) => (
+        <div key={fieldId} className="flex gap-4">
+          <input
+            className="input"
+            type="text"
+            placeholder={placeholder}
+            name={`${name}_${index}`}
+          />
+          <Button
+            type="button"
+            disabled={!canRemove}
+            onClick={() => removeField(fieldId)}
+            title="Remove this field"
+          >
+            -
+          </Button>
+          <Button
+            type="button"
+            disabled={!canAdd}
+            onClick={addField}
+            title="Add another field"
+          >
+            +
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RepeatableTextFields;

--- a/app/components/ReviewMaps.tsx
+++ b/app/components/ReviewMaps.tsx
@@ -1,0 +1,27 @@
+import type { FC } from "react";
+import type { Project } from "~/types";
+import ExternalLink from "./ExternalLink";
+
+type Props = {
+  reviewMaps: Project["attributes"]["reviewMapUrls"];
+};
+
+const ReviewMaps: FC<Props> = ({ reviewMaps = [] }) => {
+  console.log(reviewMaps);
+  if (reviewMaps.length === 0) return null;
+
+  return (
+    <section>
+      <h3 className="mt-4 mb-2 font-medium">Most impactful Review Maps</h3>
+      <ul className="list-disc list-inside">
+        {reviewMaps.map((url, i) => (
+          <li key={`map-${i}`}>
+            <ExternalLink href={url}>{url}</ExternalLink>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default ReviewMaps;

--- a/app/components/ReviewMaps.tsx
+++ b/app/components/ReviewMaps.tsx
@@ -7,7 +7,6 @@ type Props = {
 };
 
 const ReviewMaps: FC<Props> = ({ reviewMaps = [] }) => {
-  console.log(reviewMaps);
   if (reviewMaps.length === 0) return null;
 
   return (

--- a/app/routes/list-project.tsx
+++ b/app/routes/list-project.tsx
@@ -47,6 +47,8 @@ import { createNewPullRequest } from "~/github.server";
 import { getRepoOwnerAndName } from "~/utils/repo-url";
 import { getProjectByRepoUrl } from "~/projects.server";
 import ProjectSubmissionConfirmation from "~/components/ProjectSubmissionConfirmation";
+import { getRepeatableFieldValues } from "~/utils/forms";
+import RepeatableTextFields from "~/components/RepeatableTextFields";
 
 export function links() {
   return [
@@ -186,6 +188,7 @@ const ListProject: FC = () => {
         languages: maybeStringToArray(formData.get("languages")?.toString()),
         avatar: avatarSrc.src,
         featuredMap,
+        reviewMapUrls: getRepeatableFieldValues("reviewMapUrls", formData),
       },
       body: {
         contributing,
@@ -370,6 +373,77 @@ const ListProject: FC = () => {
               </div>
             </div>
           </div>
+
+          <div className="bg-white border border-light-border p-4 rounded-lg mb-8">
+            <h2 className="font-bold text-lg mb-4">CodeSee Map</h2>
+            <p>
+              We recommend providing a CodeSee Map to help onboard newcomers to
+              your project. It's free!{" "}
+              <ExternalLink href="https://app.codesee.io/maps/public/f5dcb920-ee8f-11ec-a5b3-bb55880b8b59">
+                View an example map.
+              </ExternalLink>
+            </p>
+            <div className="flex mt-6 gap-8">
+              <div className="space-y-4 w-2/3">
+                <div>
+                  <TextField
+                    label="Public Map URL"
+                    type="url"
+                    id="featuredMapUrl"
+                    placeholder="https://app.codesee.io/maps/public/example-map"
+                  />
+                  <FieldError
+                    error={actionData?.validationErrors?.featuredMapUrl}
+                  />
+                </div>
+                <div>
+                  <TextField
+                    label="Map description"
+                    id="featuredMapDescription"
+                    placeholder="Overview of our codebase"
+                  />
+                </div>
+              </div>
+              <div className="w-1/3 relative">
+                <img
+                  src={mapThumbnailSrc}
+                  width="362"
+                  height="211"
+                  alt=""
+                  className="absolute w-full h-full object-cover opacity-50 rounded-lg"
+                />
+                <div className="absolute inset-0 z-10 flex items-center justify-center">
+                  <ExternalLink
+                    href="https://app.codesee.io/maps"
+                    className="bg-light-interactive-fill px-4 py-2 rounded-lg"
+                  >
+                    Create a Map
+                  </ExternalLink>
+                </div>
+              </div>
+            </div>
+            <div className="mt-8">
+              <h2 className="font-bold text-lg mb-4">Review Maps</h2>
+              <p className="mb-4">
+                Show off some of the most impactful{" "}
+                <ExternalLink href="https://www.codesee.io/code-reviews">
+                  Review Maps
+                </ExternalLink>{" "}
+                in your repository. For example, here's{" "}
+                <ExternalLink href="https://app.codesee.io/maps/review/github/codesee-io/opensourcehub/pr/110">
+                  an important Open Source Hub PR
+                </ExternalLink>
+                .
+              </p>
+              <RepeatableTextFields
+                label="Review Maps"
+                name="reviewMapUrls"
+                maxFields={5}
+                placeholder="https://app.codesee.io/maps/review/github/codesee-io/opensourcehub/pr/110"
+              />
+            </div>
+          </div>
+
           <div className="md:flex gap-6 bg-white border border-light-border p-4 rounded-lg mb-8">
             <div className="mb-6 md:mb-0 flex-auto md:w-2/3">
               <h2 className="font-bold text-lg mb-4">Project tags</h2>
@@ -472,7 +546,8 @@ const ListProject: FC = () => {
               </div>
             </div>
           </div>
-          <div className="bg-white border border-light-border p-4 rounded-lg mb-6">
+
+          <div className="bg-white border border-light-border p-4 rounded-lg mb-20">
             <h2 className="font-bold text-lg mb-4">Content</h2>
             <div className="mb-4">
               <TextArea
@@ -493,55 +568,6 @@ const ListProject: FC = () => {
                 placeholder="How can potential contributors onboard efficiently?"
               />
               <FieldError error={actionData?.validationErrors?.contributing} />
-            </div>
-          </div>
-          <div className="bg-white border border-light-border p-4 rounded-lg mb-20">
-            <h2 className="font-bold text-lg mb-4">CodeSee Map</h2>
-            <p>
-              We recommend providing a CodeSee Map to help onboard newcomers to
-              your project. It's free!{" "}
-              <ExternalLink href="https://app.codesee.io/maps/public/f5dcb920-ee8f-11ec-a5b3-bb55880b8b59">
-                View an example map.
-              </ExternalLink>
-            </p>
-            <div className="flex mt-6 gap-8">
-              <div className="space-y-4 w-2/3">
-                <div>
-                  <TextField
-                    label="Public Map URL"
-                    type="url"
-                    id="featuredMapUrl"
-                    placeholder="https://app.codesee.io/maps/public/example-map"
-                  />
-                  <FieldError
-                    error={actionData?.validationErrors?.featuredMapUrl}
-                  />
-                </div>
-                <div>
-                  <TextField
-                    label="Map description"
-                    id="featuredMapDescription"
-                    placeholder="Overview of our codebase"
-                  />
-                </div>
-              </div>
-              <div className="w-1/3 relative">
-                <img
-                  src={mapThumbnailSrc}
-                  width="362"
-                  height="211"
-                  alt=""
-                  className="absolute w-full h-full object-cover opacity-50 rounded-lg"
-                />
-                <div className="absolute inset-0 z-10 flex items-center justify-center">
-                  <ExternalLink
-                    href="https://app.codesee.io/maps"
-                    className="bg-light-interactive-fill px-4 py-2 rounded-lg"
-                  >
-                    Create a Map
-                  </ExternalLink>
-                </div>
-              </div>
             </div>
           </div>
 

--- a/app/routes/list-project.tsx
+++ b/app/routes/list-project.tsx
@@ -440,6 +440,7 @@ const ListProject: FC = () => {
                 name="reviewMapUrls"
                 maxFields={5}
                 placeholder="https://app.codesee.io/maps/review/github/codesee-io/opensourcehub/pr/110"
+                type="url"
               />
             </div>
           </div>

--- a/app/types.ts
+++ b/app/types.ts
@@ -30,6 +30,7 @@ export type ProjectAttributes = {
     title?: string;
     url?: string;
   }[];
+  reviewMapUrls?: string[];
   maintainer: string;
   created: string;
 };

--- a/app/utils/forms.ts
+++ b/app/utils/forms.ts
@@ -1,0 +1,19 @@
+/**
+ * Use this function to extract field values from a RepeatableTextFields
+ * component. Returns a string array.
+ */
+export function getRepeatableFieldValues(name: string, formData: FormData) {
+  const values: string[] = [];
+  let index = 0;
+  do {
+    const url = formData.get(`${name}_${index}`)?.toString();
+    if (url != null && url.trim().length > 0) {
+      values.push(url);
+      index++;
+    } else {
+      index = -1;
+    }
+  } while (index !== -1);
+
+  return values;
+}

--- a/app/utils/project-submission.ts
+++ b/app/utils/project-submission.ts
@@ -7,6 +7,7 @@ import { User } from "~/types";
 import { maybeStringToArray } from "~/utils/formatting";
 import { getRepoOwnerAndName, isValidGitHubRepoUrl } from "~/utils/repo-url";
 import { getTemplateContent, ProjectTemplateFields } from "~/utils/template";
+import { getRepeatableFieldValues } from "./forms";
 
 export const MAX_AVATAR_SIZE_BYTES = 1024 * 1024 * 0.1; // 0.1 MB
 
@@ -79,6 +80,8 @@ export async function parseListProjectForm(
     avatarFileName = `${repoName}.${extension}`;
   }
 
+  const reviewMapUrls = getRepeatableFieldValues("reviewMapUrls", formData);
+
   let featuredMap: ProjectTemplateFields["featuredMap"];
   const featuredMapUrl = formData.get("featuredMapUrl")?.toString();
   const featuredMapDescription = formData
@@ -140,6 +143,7 @@ export async function parseListProjectForm(
     languages: maybeStringToArray(formData.get("languages")?.toString()),
     tags: maybeStringToArray(formData.get("tags")?.toString()),
     featuredMap,
+    reviewMapUrls,
     twitterUrl: formData.get("twitterUrl")?.toString(),
     websiteUrl: formData.get("websiteUrl")?.toString(),
   });
@@ -154,7 +158,6 @@ export async function parseListProjectForm(
 
   // If there's an avatar, upload it as a base-64 string so that GitHub knows
   // what to do
-  console.log({ avatarFile, avatarFileName });
   if (avatarFile && avatarFileName) {
     const avatarBuffer = await avatarFile.arrayBuffer();
     files.push({

--- a/app/utils/template.ts
+++ b/app/utils/template.ts
@@ -55,6 +55,7 @@ export type ProjectTemplateFields = {
   learnLinks?: { title: string; url: string }[];
   contributing?: string;
   overview?: string;
+  reviewMapUrls?: string[];
 };
 
 /**
@@ -149,6 +150,13 @@ created: ${fields.created}`;
         filledOutTemplate += "\n    subTitle: " + map.subTitle;
       }
     });
+  }
+
+  if (fields.reviewMapUrls) {
+    filledOutTemplate += stringArrayToYAMLField(
+      "reviewMapUrls",
+      fields.reviewMapUrls
+    );
   }
 
   if (fields.learnLinks) {


### PR DESCRIPTION
### What changed

I've added the ability to list Review Maps in projects. I added a `RepeatableTextFields` component that lets users add as many things as they want.

I also moved the "CodeSee" section higher up on the page.

<img width="400" alt="Screen Shot 2022-09-30 at 3 45 43 PM" src="https://user-images.githubusercontent.com/3411183/193366148-2fcd6904-e168-4a85-b598-ebff3a64304b.png">
