### PR TITLE
Flag projects that feature a CodeSee Map

### DIFF
--- a/app/components/ProjectCard.tsx
+++ b/app/components/ProjectCard.tsx
@@ -4,6 +4,7 @@ import Tag from "./Tag";
 import { GitHubData, Project } from "~/types";
 import ProjectAvatar from "./ProjectAvatar";
 import ProjectCardStats from "./ProjectCardStats";
+import MapIcon from "./icons/MapIcon";
 
 type Props = {
   project: Project;
@@ -55,6 +56,12 @@ const ProjectCard: FC<Props> = ({ project, githubData, activeTags = [] }) => {
             }}
           >
             {attributes.description}
+          </p>
+        )}
+        {attributes.featuredMap && (
+          <p className="flex gap-1 items-center text-sm text-light-type mt-2">
+            <MapIcon className="w-4 h-4 text-light-interactive" />
+            <span>Features a CodeSee Map</span>
           </p>
         )}
         <ProjectCardStats className="mt-4" stats={githubData} />


### PR DESCRIPTION
### What changed

Added a "Features a CodeSee Map" label to the projects on the home page.

### What it looks like

<img width="400" alt="Screen Shot 2022-10-03 at 11 51 26 AM" src="https://user-images.githubusercontent.com/3411183/193662623-851df75b-f66a-457d-8175-93124ad5ab8e.png">
