### PR TITLE
Display the listing date on project pages

### DIFF
--- a/app/components/ProjectTemplate.tsx
+++ b/app/components/ProjectTemplate.tsx
@@ -14,6 +14,7 @@ import HacktoberfestIssues from "~/components/markdown/HacktoberfestIssues";
 import FeaturedCodeSeeMap from "~/components/markdown/FeaturedCodeSeeMap";
 import Maps from "~/components/Maps";
 import ReviewMaps from "./ReviewMaps";
+import { formatCreatedDate } from "~/utils/formatting";
 
 type Props = {
   project: Project;
@@ -145,6 +146,13 @@ const ProjectTemplate: FC<Props> = ({
           </div>
         </div>
         <LearnSection learnLinks={project.attributes.learnLinks} />
+      </div>
+      <div className="px-4 py-8 text-center text-sm text-light-type-medium">
+        {project.attributes.created && (
+          <span>
+            Project listed on {formatCreatedDate(project.attributes.created)}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/app/utils/formatting.ts
+++ b/app/utils/formatting.ts
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+
 export function pluralize(amount: number, singular: string, plural: string) {
   return amount === 1 ? singular : plural;
 }
@@ -18,4 +20,8 @@ export function formatFileSize(size: number) {
   } else {
     return `${(size / 1048576).toFixed(1)} MB`;
   }
+}
+
+export function formatCreatedDate(date: string) {
+  return dayjs(date).format("MMMM DD, YYYY");
 }


### PR DESCRIPTION
### What changed

The "created" date of each project is now listed at the bottom of the `ProjectTemplate`.

### What it looks like

<img width="400" alt="Screen Shot 2022-10-03 at 1 45 21 PM" src="https://user-images.githubusercontent.com/3411183/193679051-92abf497-5327-44a9-b455-a4146d52f4cc.png">
