### PR TITLE
Add special treatments for verified projects

### DIFF
--- a/app/components/ProjectCard.tsx
+++ b/app/components/ProjectCard.tsx
@@ -1,5 +1,7 @@
 import { FC } from "react";
 import { Link } from "@remix-run/react";
+import cx from "classnames";
+import { VerifiedIcon } from "@primer/octicons-react";
 import Tag from "./Tag";
 import { GitHubData, Project } from "~/types";
 import ProjectAvatar from "./ProjectAvatar";
@@ -17,8 +19,12 @@ const ProjectCard: FC<Props> = ({ project, githubData, activeTags = [] }) => {
 
   return (
     <div
-      className="p-4 bg-white flex flex-col w-full rounded-lg"
-      style={{ maxWidth: 400, border: "1px solid #d8d8d8" }}
+      className={cx("p-4 bg-white flex flex-col w-full rounded-lg border", {
+        "border-light-interactive outline outline-4 outline-light-interactive-fill":
+          attributes.verified,
+        "border-light-type-disabled": !attributes.verified,
+      })}
+      style={{ maxWidth: 400 }}
     >
       {/* The container below should take up as much vertical space as possible
       so that the GitHub stats are vertically-aligned in a row even when the
@@ -33,13 +39,18 @@ const ProjectCard: FC<Props> = ({ project, githubData, activeTags = [] }) => {
             />
           )}
 
-          <h3 className="font-semibold text-light-type text-xl">
+          <h3 className="font-semibold text-light-type text-xl flex items-center gap-2">
             <Link
               to={"/" + slug}
               className="supports-hover:hover:text-light-interactive"
             >
               {attributes.name}
             </Link>
+            {attributes.verified && (
+              <span className="w-4 h-4 flex mt-0.5" title="Verified project">
+                <VerifiedIcon className="text-light-interactive" />
+              </span>
+            )}
           </h3>
         </div>
         {attributes.description && (
@@ -67,7 +78,7 @@ const ProjectCard: FC<Props> = ({ project, githubData, activeTags = [] }) => {
         <ProjectCardStats className="mt-4" stats={githubData} />
       </div>
       <div>
-        <hr className="-ml-4 -mr-4 mt-2" style={{ borderColor: "#d8d8d8" }} />
+        <hr className="-ml-4 -mr-4 mt-2 border-light-type-disabled" />
         <div className="mt-4">
           <div>
             <span className="uppercase text-light-type-medium text-xs mr-6">

--- a/app/components/ProjectTemplate.tsx
+++ b/app/components/ProjectTemplate.tsx
@@ -1,4 +1,6 @@
 import { FC } from "react";
+import cx from "classnames";
+import { VerifiedIcon } from "@primer/octicons-react";
 
 import type { CodeSeeMapMetadata, GitHubData, Project } from "~/types";
 import ProjectAvatar from "~/components/ProjectAvatar";
@@ -49,8 +51,21 @@ const ProjectTemplate: FC<Props> = ({
             />
           </div>
         )}
-        <h1 className="mt-2 mb-4 text-light-type font-semibold text-4xl">
-          {project.attributes.name}
+        <h1 className="mt-2 mb-4 font-semibold text-4xl flex items-center gap-3">
+          <span
+            className={cx({
+              "text-transparent bg-clip-text bg-gradient-to-br from-light-interactive to-indigo-850":
+                project.attributes.verified,
+              "text-light-type": !project.attributes.verified,
+            })}
+          >
+            {project.attributes.name}
+          </span>
+          {project.attributes.verified && (
+            <span className="w-5 h-5 flex mt-1" title="Verified project">
+              <VerifiedIcon className="text-light-interactive w-5 h-5" />
+            </span>
+          )}
         </h1>
         {project.attributes.featuredMap && (
           <a

--- a/app/types.ts
+++ b/app/types.ts
@@ -33,6 +33,7 @@ export type ProjectAttributes = {
   reviewMapUrls?: string[];
   maintainer: string;
   created: string;
+  verified?: boolean;
 };
 
 export type ProjectCategory = {

--- a/public/projects/distributeaid/distributeaid.org.mdx
+++ b/public/projects/distributeaid/distributeaid.org.mdx
@@ -30,6 +30,7 @@ learnLinks: # (optional) A list of links to support new contributors in learning
     url: https://www.contentful.com/developers/docs/
 maintainer: deammer
 created: 2021-09-01T13:26:37-07:00
+verified: true
 ---
 
 <Overview>


### PR DESCRIPTION
### What changed

Projects can now be marked as "verified", which makes them stand out from the other projects.

### What does it look like

On the list of projects:

<img width="400" alt="Screen Shot 2022-10-14 at 10 06 41 AM" src="https://user-images.githubusercontent.com/3411183/195905034-3c4c9a02-ac35-4a1c-8ec8-8a351fcbbb32.png">

On the individual project page:

<img width="400" alt="Screen Shot 2022-10-14 at 10 19 40 AM" src="https://user-images.githubusercontent.com/3411183/195905040-0b26b834-aa61-4306-b84a-67ce4b9c8f49.png">
