### PR TITLE
Add a new page for the Verified program

### DIFF
--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,5 +1,7 @@
 import type { MetaFunction } from "@remix-run/node";
+import { Link } from "@remix-run/react";
 import ButtonLink from "~/components/ButtonLink";
+import { ROUTES } from "~/utils/constants";
 import ExternalLink from "../components/ExternalLink";
 
 export const meta: MetaFunction = () => ({
@@ -29,9 +31,14 @@ const About = () => {
             codebase onboarding.
           </p>
           <p>
-            Maintainers can tag their projects to topics like ‘education’ and
-            ‘social good’, so contributors can search, select, and quickly
-            onboard to the projects that matter most to them.
+            Maintainers can tag their projects to topics like 'education' and
+            'social good', so contributors can search, select, and quickly
+            onboard to the projects that matter most to them. OSH also offers a{" "}
+            <Link to={ROUTES.VERIFIED} className="link">
+              Verified Program
+            </Link>{" "}
+            for maintainers to have their projects highlighted on the website
+            and within OSH's communities.
           </p>
           <p>
             Open Source Hub allows maintainers to provide contribution best

--- a/app/routes/verified.tsx
+++ b/app/routes/verified.tsx
@@ -1,0 +1,68 @@
+import type { MetaFunction } from "@remix-run/node";
+import ExternalLink from "../components/ExternalLink";
+
+export const meta: MetaFunction = () => ({
+  title: "Verified Maintainer Program",
+});
+
+const About = () => {
+  return (
+    <>
+      <header className="mx-auto max-w-2xl px-4 mb-12 pt-12 text-center">
+        <h1 className="text-3xl my-3 font-semibold text-center">
+          Verified Maintainer Program
+        </h1>
+      </header>
+      <main className="mx-auto max-w-2xl px-4 mb-20">
+        <div className="">
+          <p className="mb-4">
+            The OSH Verification program is a simple way for contributors to
+            discover projects that have been reviewed and curated by the OSH
+            team.
+          </p>
+          <p className="mb-1">Maintainers also receive many perks such as:</p>
+          <ul className="list-inside list-disc">
+            <li>
+              Distinguished promotions on the OSH website and its communities
+            </li>
+            <li>Featured in Console by OSH weekly newsletter</li>
+            <li>Access to a CodeSee Business or Enterprise Plan</li>
+            <li>...and many more benefits!</li>
+          </ul>
+        </div>
+        <div className="p-6 bg-white rounded-lg border border-light-border my-12">
+          <h2 className="text-xl font-semibold mb-4">How to get verified</h2>
+          <p className="mb-4">
+            Want to get verified? Our two requirements are that your project is
+            active and noteworthy. Learn more about what's required before
+            following the steps to submit your project for Verification.
+          </p>
+          <p className="font-bold mb-1">Active</p>
+          <p className="mb-4">
+            Verified projects are actively maintained and receive at least 4+
+            PRs from contributors every 30 days.
+          </p>
+          <p className="font-bold mb-1">Noteworthy</p>
+          <p>
+            Verified projects are widely known and/or impactful in the world of
+            open source. Noteworthiness is determined through the purpose of the
+            project, number of stars, notable maintainers/contributors working
+            on the project, etc.
+          </p>
+        </div>
+        <div className="space-y-4 p-6 bg-white rounded-lg border border-light-border text-center">
+          <h2 className="text-lg font-semibold mb-2">
+            Submit your project to be verified on Open Source Hub today!
+          </h2>
+          <p>
+            <ExternalLink href="https://forms.gle/xnoTCrRzazZrSVG96">
+              Get verified!
+            </ExternalLink>
+          </p>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default About;

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -15,6 +15,7 @@ export const ROUTES = {
   PRIVACY: "/privacy",
   TERMS_CONDITIONS: "/terms-conditions",
   LIST_PROJECT: "/list-project",
+  VERIFIED: "/verified",
 };
 
 // Button, Link Types


### PR DESCRIPTION
### What changed

- added a new page for the verification program at the `/verified` path
- mentioned the new page in the About page

### Pixels

The new page:

![Screen Shot 2022-11-15 at 11 58 22-fullpage](https://user-images.githubusercontent.com/3411183/202013749-df66c6f8-6cbc-4eb8-b4ff-6fbf1d15bdce.png)


The updated About page:

![Screen Shot 2022-11-15 at 11 58 40-fullpage](https://user-images.githubusercontent.com/3411183/202013796-d05c1bf3-befd-4bd2-9ee6-1fd0d8a33f56.png)
