### PR TITLE
Set the X-Frame-Options header

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -14,6 +14,9 @@ export default function handleRequest(
 
   responseHeaders.set("Content-Type", "text/html");
 
+  // We can only be iframed if all ancestor frames match our origin
+  responseHeaders.set("X-Frame-Options", "SAMEORIGIN");
+
   return new Response("<!DOCTYPE html>" + markup, {
     status: responseStatusCode,
     headers: responseHeaders,


### PR DESCRIPTION
### What changed

Every page now returns the `X-Frame-Options: SAMEORIGIN` header. This prevents malicious sites from iframing us and reduces the risk of click-jacking.

[Learn more here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options).