### PR TITLE
Feature: join our newsletter

### DIFF
--- a/app/routes/u.github/$slug/welcome.tsx
+++ b/app/routes/u.github/$slug/welcome.tsx
@@ -100,7 +100,7 @@ const Welcome: FC = () => {
             </p>
             <Form
               method="post"
-              action="/u/github/update-profile"
+              action="/u/github/complete-welcome-form"
               onSubmit={onFormSubmit}
             >
               <div className="lg:flex gap-8">
@@ -194,14 +194,18 @@ const Welcome: FC = () => {
                   </div>
                 </div>
               </div>
-              <div className="pt-10">
-                <label className="text-sm flex gap-2 font-semibold text-light-type-medium mb-4 cursor-pointer">
+              <div className="pt-10 space-y-4">
+                <label className="text-sm flex gap-2 font-semibold text-light-type-medium cursor-pointer">
                   <input type="checkbox" name="isProjectMaintainer" />I am an
                   open-source project maintainer
                 </label>
-                <label className="text-sm flex gap-2 font-semibold text-light-type-medium  cursor-pointer">
+                <label className="text-sm flex gap-2 font-semibold text-light-type-medium cursor-pointer">
                   <input type="checkbox" name="joinDiscord" />
                   Join the Open Source Hub Discord server
+                </label>
+                <label className="text-sm flex gap-2 font-semibold text-light-type-medium cursor-pointer">
+                  <input type="checkbox" name="joinNewsletter" defaultChecked />
+                  Subscribe to our newsletter to follow the latest OSS news
                 </label>
               </div>
               <div className="mt-16 flex justify-end gap-6">

--- a/app/routes/u.github/complete-welcome-form.ts
+++ b/app/routes/u.github/complete-welcome-form.ts
@@ -35,6 +35,9 @@ export const action: ActionFunction = async ({ request }) => {
     formData.get("roleInterests")?.toString()
   );
 
+  const isProjectMaintainer = !!formData.get("isProjectMaintainer");
+  const joinNewsletter = !!formData.get("joinNewsletter");
+
   const updatedProfile: Partial<UserProfile> = {
     userId: currentUser.uid,
     pictureUrl: currentUser.pictureUrl,
@@ -44,6 +47,8 @@ export const action: ActionFunction = async ({ request }) => {
     subjectInterests,
     roleInterests,
     intro,
+    isProjectMaintainer,
+    joinNewsletter,
   };
 
   if (typeof displayName === "string" && displayName.length > 0) {

--- a/app/types.ts
+++ b/app/types.ts
@@ -135,6 +135,7 @@ export type UserProfile = {
   roleInterests?: string[];
   portfolioItems?: string[];
   isProjectMaintainer?: boolean;
+  joinNewsletter?: boolean;
 };
 
 export type Tag = {


### PR DESCRIPTION
### What changed

I added the ability to join our newsletter from the "Welcome" screen. Users will see this when they create a profile on OSH.

The "Welcome" screen now has its own form handler. It used to share the same handler as the profile update, but the data has diverged.

New checkbox:

<img width="400" alt="Screenshot 2023-01-25 at 4 54 54 PM" src="https://user-images.githubusercontent.com/3411183/214730459-4acf8f03-1e88-40db-9796-5504afcd46a6.png">
