### PR TITLE
Improvement: updated copy on newsletter opt-in

### DIFF
--- a/app/routes/u.github/$slug/welcome.tsx
+++ b/app/routes/u.github/$slug/welcome.tsx
@@ -205,7 +205,7 @@ const Welcome: FC = () => {
                 </label>
                 <label className="text-sm flex gap-2 font-semibold text-light-type-medium cursor-pointer">
                   <input type="checkbox" name="joinNewsletter" defaultChecked />
-                  Subscribe to our newsletter to follow the latest OSS news
+                  Subscribe to our newsletter called, "Console by CodeSee.io", to follow the latest OSS news
                 </label>
               </div>
               <div className="mt-16 flex justify-end gap-6">


### PR DESCRIPTION
### What changed:
Improved copy on the open source newsletter subscription opt-in.

The opt-in sentence now has more context on what our newsletter is called so that users recognize the newsletter name when they receive our newsletter subscription confirmation.