### PR TITLE
Add a link to the Verified page

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -38,6 +38,12 @@ const Footer: FC = () => (
       >
         Discord
       </a>
+      <Link
+        className="supports-hover:hover:text-yellow-300"
+        to={ROUTES.VERIFIED}
+      >
+        Get verified
+      </Link>
     </div>
     <div className="flex gap-2 md:gap-6 flex-col md:flex-row text-sm text-white text-center justify-center mb-10">
       <Link


### PR DESCRIPTION
### What changed

I added a link to the [verified page](https://opensourcehub.io) in the footer.

<img width="643" alt="Screenshot 2023-02-06 at 8 54 51 AM" src="https://user-images.githubusercontent.com/3411183/217034634-5ab55f25-0fea-4541-92d8-89ecac005f20.png">
