### PR TITLE
Hotfix: project validation can throw error

### DIFF
--- a/app/routes/list-project.tsx
+++ b/app/routes/list-project.tsx
@@ -141,7 +141,7 @@ const ListProject: FC = () => {
 
   useEffect(() => {
     // Scroll to the top of the page when we receive validation errors
-    if (actionData != null) {
+    if (actionData?.validationErrors != null) {
       const errorKeys = Object.keys(actionData.validationErrors);
       if (errorKeys.length > 0) {
         window.scrollTo(0, 0);


### PR DESCRIPTION
### What changed?

I fixed an error where an undefined key could throw an error. This could happen when adding projects to the site 😢 