### PR TITLE
Escape colons in project submission form

### DIFF
--- a/app/utils/template.ts
+++ b/app/utils/template.ts
@@ -66,7 +66,8 @@ export function getTemplateContent(fields: ProjectTemplateFields) {
   let filledOutTemplate = `---
 name: ${fields.name}
 repoUrl: ${fields.repoUrl}
-description: ${fields.description}
+description: >
+  ${fields.description}
 maintainer: ${fields.maintainer}
 created: ${fields.created}`;
 


### PR DESCRIPTION
When people use colons in project descriptions, it breaks the YAML file that we automatically generate.

This PR makes sure that doesn't happen!

Invalid YAML:

```yaml:
description: hello: there
```

Valid YAML:

```yaml:
description: >
  hello: there
```


