### PR TITLE
Show a shutdown banner

### DIFF
--- a/app/components/RootLayout.tsx
+++ b/app/components/RootLayout.tsx
@@ -11,6 +11,9 @@ const RootLayout: FC<Props> = ({ children, userInfo }) => {
   return (
     <div className="flex flex-col min-h-screen">
       <Header userInfo={userInfo} />
+      <div className="p-2 text-center bg-white text-light-type border-b border-light-border">
+        Open Source Hub is shutting down on February 22, 2024.
+      </div>
       <main className="flex-grow">{children}</main>
       <Footer />
     </div>


### PR DESCRIPTION
Warn users that the site will shut down on February 22.

<img width="1242" alt="Screenshot 2024-02-20 at 4 10 11 PM" src="https://github.com/Codesee-io/opensourcehub/assets/3411183/3e49b24a-a4fc-4af3-8fc7-eba0be1653b7">
